### PR TITLE
Mateo submit responses

### DIFF
--- a/react-ui/src/components/Reviewer/GroupNames.js
+++ b/react-ui/src/components/Reviewer/GroupNames.js
@@ -22,21 +22,25 @@ class GroupNames extends Component {
     this.setState({ names });
   }
 
+  handleUpdateReviewId(reviewId) {
+    this.props.updateReviewId(reviewId);
+  }
+
   handleSubmit(e) {
     e.preventDefault();
     console.log(typeof this.state.names, this.state.names, this.props.match.params.id);
     let thiz = this;
     console.log(this.state.names);
     // save group to groups table, names to reviewers table, and review to review table
-    // TODO persist / find a way to access the review_id for all the questions
     axios.post('/api/add-group', {
       names: this.state.names,
-      // group_name: '', // in the future, we could let students name their team.
       mission_id: this.props.match.params.id,
+      // group_name: '', // in the future, we could let students name their team.
     })
     .then((res) => {
       console.log("group added", res)
-      thiz.setState({ submitGroup: true })
+      this.handleUpdateReviewId(res.data.group_id);
+      thiz.setState({ submitGroup: true });
     })
     .catch((err) => {
       console.log("error in adding group: ", err)
@@ -44,9 +48,6 @@ class GroupNames extends Component {
       thiz.setState({ submitGroup: true })
     });
   }
-
-  // TODO
-  // Warning: setState(...): Can only update a mounted or mounting component. This usually means you called setState() on an unmounted component. This is a no-op. Please check the code for the GroupNames component.
 
   render() {
     const { id, casefile_id } = this.props.match.params;

--- a/react-ui/src/components/Reviewer/Mission.js
+++ b/react-ui/src/components/Reviewer/Mission.js
@@ -15,9 +15,11 @@ class Article extends Component {
       headline: '',
       url: '',
       article: {},
+      reviewId: '',
       missionId: this.props.match.params.id,
       casefileId: this.props.match.params.casefile_id,
     };
+    this.updateReviewId = this.updateReviewId.bind(this);
   }
 
   getRandomIntInclusive(min, max) {
@@ -45,6 +47,10 @@ class Article extends Component {
       })
   }
 
+  updateReviewId(reviewId) {
+    this.setState({ reviewId: reviewId });
+  }
+
   render() {
     const bodyStyles = {
       flexGrow: 1,
@@ -58,15 +64,21 @@ class Article extends Component {
       flexDirection: 'column',
     }
 
-    const previewProps = this.state
+    const missionState = this.state;
 
     return (
       <div style={articleContainer}>
         <div className="flex-column" style={bodyStyles}>
           <Route exact path="/mission/:id/casefile/:casefile_id/start" component={Start} />
-          <Route exact path="/mission/:id/casefile/:casefile_id/team" component={GroupNames} />
-          <Route exact path="/mission/:id/casefile/:casefile_id/article/preview" render={() => <ArticlePreview {...previewProps} />} />
-          <Route exact path="/mission/:id/casefile/:casefile_id/article/:article_id/question/:id" component={Questions} />
+          <Route exact path="/mission/:id/casefile/:casefile_id/team"
+            render={() => <GroupNames updateReviewId={this.updateReviewId} {...this.props} />}
+          />
+          <Route exact path="/mission/:id/casefile/:casefile_id/article/preview"
+            render={() => <ArticlePreview {...missionState} />}
+          />
+          <Route exact path="/mission/:id/casefile/:casefile_id/article/:article_id/question/:id"
+            render={() => <Questions {...missionState} {...this.props} />}
+          />
         </div>
         <Footer {...this.props} />
       </div>

--- a/react-ui/src/components/Reviewer/Questions.js
+++ b/react-ui/src/components/Reviewer/Questions.js
@@ -42,7 +42,7 @@ class Questions extends Component {
     axios.patch(`/api/add-response/${review_id}`, {
       // review_id: review_id,
       question: question,
-      answer: answer,
+      response: answer,
     })
     .then((res) => {
       console.log('response posted', res)

--- a/react-ui/src/components/Reviewer/Questions.js
+++ b/react-ui/src/components/Reviewer/Questions.js
@@ -10,22 +10,12 @@ class Questions extends Component {
   constructor(props) {
     super(props);
     this.handleSubmit = this.handleSubmit.bind(this);
-    this.updateAnswer = this.updateAnswer.bind(this);
-    this.handleChange = this.handleChange.bind(this);
+    this.handleInputChange = this.handleInputChange.bind(this);
     this.state = {
       answer: '',
       submitResponse: false,
       questionsLeft: 0, // TODO need some way to stop at the last question and go to the final page
     };
-  }
-
-  updateAnswer(e) {
-    e.preventDefault;
-    const answer = this.refs.input ? this.refs.input.value : this.state.answer;
-    this.setState({
-      answer: answer,
-    })
-    this.handleSubmit(answer);
   }
 
   //submit question and answer to reviews route
@@ -34,7 +24,7 @@ class Questions extends Component {
     let answer = this.state.answer;
     console.log(this.refs.input);
     let question = find(Number(this.props.match.params.id) - 1).questionText;
-    let review_id; - // TODO where is the review_id? how can we access it here? componentDidMount?
+    let review_id; // TODO where is the review_id? how can we access it here? componentDidMount?
     console.log("answer", answer); // TODO this is coming back undefined no matter how I try to get it
     console.log("question", question);
 
@@ -57,9 +47,10 @@ class Questions extends Component {
 
   }
 
-  handleChange(e) {
-    this.setState({answer: e.target.value})
+  handleInputChange(e) {
+    this.setState({ answer: e.target.value })
   }
+
   render() {
     console.log("props", this.props);
     const { match } = this.props
@@ -71,13 +62,18 @@ class Questions extends Component {
     const article = match.params.article_id;
     const submitResponse = this.state.submitResponse;
     console.log("submitResponse", submitResponse);
+
     return (
       <div className="text-center">
         <form onSubmit={(e) => this.handleSubmit(e)}>
           <h1>{question.questionText}</h1>
-          <input type="text" className="question--short" defaultValue={this.state.answer} onChange={this.handleChange}/>
-          <br></br><br></br>
-          <Button onClick={(e) => this.updateAnswer(e)}>Save and Continue</Button>
+          <input type="text" className="question--short"
+            defaultValue={this.state.answer}
+            onChange={this.handleInputChange}
+          />
+          <button className="button Questions__submit-button">
+            Save and Continue
+          </button>
         </form>
         {submitResponse && (
           <Redirect to={`/mission/1/casefile/${casefile}/article/${article}/question/${nextQuestion}`}/>

--- a/react-ui/src/components/Reviewer/Questions.js
+++ b/react-ui/src/components/Reviewer/Questions.js
@@ -21,16 +21,14 @@ class Questions extends Component {
   //submit question and answer to reviews route
   handleSubmit(e) {
     e.preventDefault;
-    let answer = this.state.answer;
-    console.log(this.refs.input);
-    let question = find(Number(this.props.match.params.id) - 1).questionText;
-    let review_id; // TODO where is the review_id? how can we access it here? componentDidMount?
-    console.log("answer", answer); // TODO this is coming back undefined no matter how I try to get it
-    console.log("question", question);
+
+    const answer = this.state.answer;
+    const question = find(Number(this.props.match.params.id) - 1).questionText;
+    const { reviewId } = this.props;
 
     // on question submits save review_id and question and answer to responses table
-    axios.patch(`/api/add-response/${review_id}`, {
-      // review_id: review_id,
+    axios.patch(`/api/add-response/${reviewId}`, {
+      review_id: reviewId,
       question: question,
       response: answer,
     })
@@ -44,7 +42,6 @@ class Questions extends Component {
     .catch((err) => {
       console.log('response error', err);
     })
-
   }
 
   handleInputChange(e) {

--- a/react-ui/src/components/Reviewer/_Questions.scss
+++ b/react-ui/src/components/Reviewer/_Questions.scss
@@ -1,0 +1,6 @@
+.Questions__submit-button {
+  clear: both;
+  display: block;
+  text-align: center;
+  margin: 20px auto;
+}

--- a/react-ui/src/scss/index.css
+++ b/react-ui/src/scss/index.css
@@ -274,6 +274,12 @@ p, .p {
   flex-direction: column;
   align-items: center; }
 
+.Questions__submit-button {
+  clear: both;
+  display: block;
+  text-align: center;
+  margin: 20px auto; }
+
 html, body {
   width: 100%;
   height: 100%;

--- a/react-ui/src/scss/index.scss
+++ b/react-ui/src/scss/index.scss
@@ -18,6 +18,7 @@
 @import "../components/Reviewer/Footer";
 @import "../components/Reviewer/ProgressBar";
 @import "../components/Reviewer/GroupNames";
+@import "../components/Reviewer/Questions";
 
 html, body {
   width: 100%;

--- a/server/routes/groups.js
+++ b/server/routes/groups.js
@@ -55,16 +55,12 @@ router.post('/api/add-group', (req, res, next) => {
     .save()
     .then((review) => {
       console.log("review", review.id);
-      // res.send(review.id);
       Response.forge({
         review_id: review.id,
       })
       .save()
+      res.status(200).json(review)
     })
-  })
-  .then(() => {
-    res.sendStatus(200);
-    // res.status(200).json(group) //these seemed to be causing errors..? it might have been something else though
   })
   .catch((err) => {
     console.log("group post error", err);

--- a/server/routes/groups.js
+++ b/server/routes/groups.js
@@ -36,8 +36,9 @@ router.post('/api/add-group', (req, res, next) => {
   .save()
   .then((group) => {
     groupId = group.id;
-      for (var i = 0; i < req.body.names.length; i++) {
-        if (req.body.names[i] !== '') {
+
+    for (var i = 0; i < req.body.names.length; i++) {
+      if (req.body.names[i] !== '') {
         Reviewer.forge({
           group_id: groupId,
           name: req.body.names[i]


### PR DESCRIPTION
Hey @rallyjinx, I'm hoping to address in this PR some of your questions from #103.

The reason the text input was not getting sent through to the server is because we were calling the parameter "answer" and it was expecting "response"
https://github.com/civicparty/legitometer/compare/rally-submit-responses...mateo-submit-responses?expand=1#diff-d5659b36f10be02db3b52b1d0a29d512L45

As for persisting the Review ID (which I think might be the same as a group id?), we could persist it in the URL (but that gets sloppy as it already is the with casefile and mission ids). So what we should do is have it stored in the state of a parent component. The Reviewer Mission component seemed like a good place so that's what I tried.

Now, I'm running into a dead end in the endpoint you created to add a response. We look for a "Response" that has the "review_id" we pass with the params. Should it be a Review instead?
https://github.com/civicparty/legitometer/blob/c38e45a55885beca8cec3e4275d08e4d86053030/server/routes/responses.js#L14-L18

Happy to talk about this more when we meet up this week. Also note the comments I make next to code below...
